### PR TITLE
Fix CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Installing OpenGL
-          command: |
-            apt update
-            apt -y install libgl1-mesa-swx11
-      - run:
           name: Installing Gtk2
           command: |
             apt -y install libgtk2.0-dev


### PR DESCRIPTION
Don't install OpenGL as it may no longer be needed (due to a change from debian jessie to stretch)