### PR TITLE
Try and unpin package versions for glue-geospatial

### DIFF
--- a/build_packages.ps1
+++ b/build_packages.ps1
@@ -43,11 +43,11 @@ if ($env:STABLE -match "false") {
 
 if ($env:STABLE -match "false") {
   # $packages = @("glue-core", "glue-medical", "glue-vispy-viewers", "glueviz", "glue-wwt", "glue-geospatial", "glue-samp", "glue-exp")
-  $packages = @("glue-core", "glue-medical", "glue-vispy-viewers", "glueviz", "glue-wwt")
+  $packages = @("glue-core", "glue-medical", "glue-vispy-viewers", "glueviz", "glue-wwt", "glue-geospatial")
   checkLastExitCode
 } else {
   # $packages = @("glue-core", "glue-medical", "glue-vispy-viewers", "glueviz", "glue-wwt", "glue-geospatial", "glue-samp")
-  $packages = @("glue-core", "glue-medical", "glue-vispy-viewers", "glueviz", "glue-wwt")
+  $packages = @("glue-core", "glue-medical", "glue-vispy-viewers", "glueviz", "glue-wwt", "glue-geospatial")
   checkLastExitCode
 }
 

--- a/recipes/glue-geospatial/meta.yaml
+++ b/recipes/glue-geospatial/meta.yaml
@@ -16,21 +16,12 @@ requirements:
 
   run:
     - python
-    # Numpy needs to be pinned to 1.12 (the latest version that
-    # there is a rasterio package for) otherwise there is a
-    # conflict according to conda
-    - numpy 1.12.*
+    - numpy
     - astropy
     - pyproj
     - rasterio
     - affine
     - glue-core >=0.12
-
-    # Pin version of the jpeg library to avoid issues on MacOS X
-    # where libgdal appears to be built against jpeg 8 but doesn't
-    # declare that pinning, causing issues now that jpeg 9 is
-    # available.
-    - jpeg 8*  # [osx]
 
 test:
   imports:


### PR DESCRIPTION
It looks like rasterio for Windows has been updated in defaults, as has libgdal for MacOS X